### PR TITLE
Smartplug - current & voltage

### DIFF
--- a/app.json
+++ b/app.json
@@ -2937,7 +2937,9 @@
       "capabilities": [
         "onoff",
         "measure_power",
-        "meter_power"
+        "meter_power",
+        "measure_current",
+        "measure_voltage"
       ],
       "capabilitiesOptions": {
         "measure_power": {
@@ -3033,6 +3035,132 @@
             "max": 1.2,
             "step": 0.1
           }
+        },
+        {
+          "id": "minReportPower",
+          "type": "number",
+          "label": {
+            "en": "Min report interval for power (s)"
+          },
+          "hint": {
+            "en": "Min interval before a report is sent to Homey (s)"
+          },
+          "value": 60,
+          "attr": {
+            "step": 1,
+            "min": 10,
+            "max": 86400
+          }
+        },
+        {
+          "id": "minReportCurrent",
+          "type": "number",
+          "label": {
+            "en": "Min report interval for current (s)"
+          },
+          "hint": {
+            "en": "Min interval before a report is sent to Homey (s)"
+          },
+          "value": 60,
+          "attr": {
+            "step": 1,
+            "min": 10,
+            "max": 86400
+          }
+        },
+        {
+          "id": "minReportVoltage",
+          "type": "number",
+          "label": {
+            "en": "Min report interval for voltage (s)"
+          },
+          "hint": {
+            "en": "Min interval before a report is sent to Homey (s)"
+          },
+          "value": 60,
+          "attr": {
+            "step": 1,
+            "min": 10,
+            "max": 86400
+          }
+        },
+        {
+          "id": "relay_status",
+          "type": "radio",
+          "label": {
+            "en": "Relay status"
+          },
+          "value": "2",
+          "values": [
+            {
+              "id": "0",
+              "label": {
+                "en": "Off"
+              }
+            },
+            {
+              "id": "1",
+              "label": {
+                "en": "On"
+              }
+            },
+            {
+              "id": "2",
+              "label": {
+                "en": "Remember last status"
+              }
+            }
+          ]
+        },
+        {
+          "id": "indicator_mode",
+          "type": "radio",
+          "label": {
+            "en": "Indicator mode"
+          },
+          "value": "1",
+          "values": [
+            {
+              "id": "0",
+              "label": {
+                "en": "Off"
+              }
+            },
+            {
+              "id": "1",
+              "label": {
+                "en": "Indicates status. The indicator comes on when the switch is turned on."
+              }
+            },
+            {
+              "id": "2",
+              "label": {
+                "en": "Indicates position. The indicator comes on when the switch is turned off."
+              }
+            }
+          ]
+        },
+        {
+          "id": "child_lock",
+          "type": "radio",
+          "label": {
+            "en": "Child lock"
+          },
+          "value": "0",
+          "values": [
+            {
+              "id": "0",
+              "label": {
+                "en": "Release"
+              }
+            },
+            {
+              "id": "1",
+              "label": {
+                "en": "Lock"
+              }
+            }
+          ]
         }
       ]
     },

--- a/drivers/smartplug/driver.compose.json
+++ b/drivers/smartplug/driver.compose.json
@@ -9,7 +9,9 @@
   "capabilities": [
     "onoff",
     "measure_power",
-    "meter_power"
+    "meter_power",
+    "measure_current",
+    "measure_voltage"
   ],
   "capabilitiesOptions": {
     "measure_power": {

--- a/drivers/smartplug/driver.settings.compose.json
+++ b/drivers/smartplug/driver.settings.compose.json
@@ -30,5 +30,131 @@
       "max": 1.2,
       "step": 0.1
     }
+  },
+  {
+    "id": "minReportPower",
+    "type": "number",
+    "label": {
+      "en": "Min report interval for power (s)"
+    },
+    "hint": {
+      "en": "Min interval before a report is sent to Homey (s)"
+    },
+    "value": 60,
+    "attr": {
+      "step": 1,
+      "min": 10,
+      "max": 86400
+    }
+  },
+  {
+    "id": "minReportCurrent",
+    "type": "number",
+    "label": {
+      "en": "Min report interval for current (s)"
+    },
+    "hint": {
+      "en": "Min interval before a report is sent to Homey (s)"
+    },
+    "value": 60,
+    "attr": {
+      "step": 1,
+      "min": 10,
+      "max": 86400
+    }
+  },
+  {
+    "id": "minReportVoltage",
+    "type": "number",
+    "label": {
+      "en": "Min report interval for voltage (s)"
+    },
+    "hint": {
+      "en": "Min interval before a report is sent to Homey (s)"
+    },
+    "value": 60,
+    "attr": {
+      "step": 1,
+      "min": 10,
+      "max": 86400
+    }
+  },
+  {
+    "id": "relay_status",
+    "type": "radio",
+    "label": {
+      "en": "Relay status"
+    },
+    "value": "2",
+    "values": [
+      {
+        "id": "0",
+        "label": {
+          "en": "Off"
+        }
+      },
+      {
+        "id": "1",
+        "label": {
+          "en": "On"
+        }
+      },
+      {
+        "id": "2",
+        "label": {
+          "en": "Remember last status"
+        }
+      }
+    ]
+  },
+  {
+    "id": "indicator_mode",
+    "type": "radio",
+    "label": {
+      "en": "Indicator mode"
+    },
+    "value": "1",
+    "values": [
+      {
+        "id": "0",
+        "label": {
+          "en": "Off"
+        }
+      },
+      {
+        "id": "1",
+        "label": {
+          "en": "Indicates status. The indicator comes on when the switch is turned on."
+        }
+      },
+      {
+        "id": "2",
+        "label": {
+          "en": "Indicates position. The indicator comes on when the switch is turned off."
+        }
+      }
+    ]
+  },
+  {
+    "id": "child_lock",
+    "type": "radio",
+    "label": {
+      "en": "Child lock"
+    },
+    "value": "0",
+    "values": [
+      {
+        "id": "0",
+        "label": {
+          "en": "Release"
+        }
+      },
+      {
+        "id": "1",
+        "label": {
+          "en": "Lock"
+        }
+      }
+    ]
   }
 ]

--- a/lib/TuyaOnOffCluster.js
+++ b/lib/TuyaOnOffCluster.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const { ZCLDataTypes, OnOffCluster} = require('zigbee-clusters');
+
+ZCLDataTypes.enum8IndicatorMode = ZCLDataTypes.enum8({
+  Off                     : 0x00,
+  Status                  : 0x01,
+  Position                : 0x02
+});
+ZCLDataTypes.enum8RelayStatus = ZCLDataTypes.enum8({
+  Off                    : 0x00,
+  On                     : 0x01,
+  Remember               : 0x02
+});
+
+class TuyaOnOffCluster extends OnOffCluster {
+
+  static get ATTRIBUTES() {
+    return {
+      ...super.ATTRIBUTES,
+      childLock: { id: 0x8000, type: ZCLDataTypes.bool},
+      indicatorMode: { id: 0x8001, type: ZCLDataTypes.enum8IndicatorMode},
+      relayStatus: { id: 0x8002, type: ZCLDataTypes.enum8RelayStatus},
+    };
+  }
+}
+
+module.exports = TuyaOnOffCluster;


### PR DESCRIPTION
This PR adds support for **measure_current** and **measure_voltage** capability in Homey using smartplug. 
Also adds option to set min interval for polling, relay status, child lock. 

Based on: https://developer.tuya.com/en/docs/iot/tuya-zigbee-measuring-smart-plug-access-standard?id=K9ik6zvofpzqk#title-4-On%2FOff%20cluster 

Verfied with TS011F / _TZ3000_amdymr7l