### PR TITLE
Update driver.compose.json with manufacturer _TZ3000_dbpmpco1

### DIFF
--- a/drivers/wall_curtain_switch/driver.compose.json
+++ b/drivers/wall_curtain_switch/driver.compose.json
@@ -23,7 +23,8 @@
       "manufacturerName": [
         "_TZ3000_dph3rpss",
         "_TZ3000_8kzqqzu4",
-        "_TZ3000_ltiqubue"
+        "_TZ3000_ltiqubue",
+        "_TZ3000_dbpmpco1"
       ],
       "productId": [
         "TS130F"
@@ -37,7 +38,7 @@
       "learnmode": {
         "image": "{{driverAssetsPath}}/icon.svg",
         "instruction": {
-          "en": "Power on/off 5 times to enter pairing mode (the LED should blink / device starts beeping)."
+          "en": "Power on/off 5 times to enter pairing mode (the LED should blink / device starts beeping) or press the Pause-button 5sec until Open-button blinks."
         }
       }
     }


### PR DESCRIPTION
Added manufacturer _TZ3000_dbpmpco1 (Loratap, Model No SC400ZB, SC420ZB) for Wall Mounted Curtain Switch. Works fine. Calibration is however needed (for any curtain taking more than 1 minute to fully close or open). 
 