### PR TITLE
Added manufacturer "_TZ3000_b28wrpvx" (BSeed, Wall Outlet with metering)

### DIFF
--- a/drivers/smartplug/driver.compose.json
+++ b/drivers/smartplug/driver.compose.json
@@ -48,7 +48,8 @@
       "_TZ3000_5f43h46b",
       "_TZ3000_fqoynhku",
       "_TZ3000_ynmowqk2",
-      "_TZ3000_kx0pris5"
+      "_TZ3000_kx0pris5",
+      "_TZ3000_b28wrpvx"
     ],
     "productId": [
       "TS0121",


### PR DESCRIPTION
The "_TZ3000_b28wrpvx" Wall Outlet works according the smartplug. The Wall Outlet is strictly speaking not a plug, but the metering seems to be fairly accurate and it works fine for already a month or so. As one would have a specific device plugged in (a washing machine or dryer) one can always change the icon.