### PR TITLE
Add support for Smart Plug 20A EU

### DIFF
--- a/app.json
+++ b/app.json
@@ -3077,7 +3077,8 @@
           "_TZ3000_5f43h46b",
           "_TZ3000_fqoynhku",
           "_TZ3000_ynmowqk2",
-          "_TZ3000_kx0pris5"
+          "_TZ3000_kx0pris5",
+          "_TZ3000_gvn91tmx"
         ],
         "productId": [
           "TS0121",

--- a/drivers/smartplug/driver.compose.json
+++ b/drivers/smartplug/driver.compose.json
@@ -48,7 +48,8 @@
       "_TZ3000_5f43h46b",
       "_TZ3000_fqoynhku",
       "_TZ3000_ynmowqk2",
-      "_TZ3000_kx0pris5"
+      "_TZ3000_kx0pris5",
+      "_TZ3000_gvn91tmx"
     ],
     "productId": [
       "TS0121",


### PR DESCRIPTION
This PR adds support for Manufacturer name `_TZ3000_gvn91tmx` which is the Tuya Smart Plug 20A EU https://zigbee.blakadder.com/Tuya_TS011F_20A.html manufactured by brands such as Aubess.