### PR TITLE
4 Gang Wall Switch: Swapping buttons to correct layout

### DIFF
--- a/drivers/wall_remote_4_gang/device.js
+++ b/drivers/wall_remote_4_gang/device.js
@@ -37,7 +37,7 @@ class wall_remote_4_gang extends ZigBeeDevice {
     }
 
     buttonCommandParser(ep, frame) {
-      var button = ep === 1 ? 'leftDown' : ep === 2 ? 'rightDown' : ep === 3 ? 'rightUp' : 'leftUp';
+      var button = ep === 1 ? 'leftUp' : ep === 2 ? 'rightUp' : ep === 3 ? 'leftDown' : 'rightDown';
       var action = frame.data[3] === 0 ? 'oneClick' : 'twoClicks';
       return this._buttonPressedTriggerDevice.trigger(this, {}, { action: `${button}-${action}` })
       .then(() => this.log(`Triggered 4 Gang Wall Remote, action=${button}-${action}`))


### PR DESCRIPTION
The current 4-gang wall-switch has an incorrect button layout, at least for model TZ_3000_wkai4ga5 (TS0044). This PR corrects just the button mapping to a tested correct layout.