### PR TITLE
Added PIR sensor support for TS0202/_TZ3040_bb6xaihh

### DIFF
--- a/drivers/pir_sensor_2/driver.compose.json
+++ b/drivers/pir_sensor_2/driver.compose.json
@@ -28,7 +28,8 @@
       "_TZ3000_msl6wxk9",
       "_TZ3000_mcxw5ehu",
       "_TZ3000_otvn3lne",
-      "_TZ3000_6ygjfyll"
+      "_TZ3000_6ygjfyll",
+      "_TZ3040_bb6xaihh"
     ],
     "productId": [
       "TS0202"


### PR DESCRIPTION
Just added the manufacturer name _TZ3040_bb6xaihh in the list. After that the sensor is working perfectly.