### PR TITLE
Remove the debounce for the switch _TZ3000_wkai4ga5

### DIFF
--- a/drivers/wall_remote_4_gang_3/device.js
+++ b/drivers/wall_remote_4_gang_3/device.js
@@ -29,7 +29,7 @@ class wall_remote_4_gang_3 extends ZigBeeDevice {
         }
       };
 
-      this._buttonPressedTriggerDevice = this.homey.flow.getDeviceTriggerCard('wall_remote_4_gang_buttons')
+      this._buttonPressedTriggerDevice = this.homey.flow.getDeviceTriggerCard('wall_remote_4_gang_buttons_3')
       .registerRunListener(async (args, state) => {
         return (null, args.action === state.action);
       });

--- a/drivers/wall_remote_4_gang_3/device.js
+++ b/drivers/wall_remote_4_gang_3/device.js
@@ -7,25 +7,15 @@ class wall_remote_4_gang_3 extends ZigBeeDevice {
 
     async onNodeInit({zclNode}) {
 
-      var debounce = 0;
       this.printNode();
-
+      
       const node = await this.homey.zigbee.getNode(this);
       node.handleFrame = (endpointId, clusterId, frame, meta) => {
         if (clusterId === 6) {
            this.log("endpointId:", endpointId,", clusterId:", clusterId,", frame:", frame, ", meta:", meta);
            this.log("Frame JSON data:", frame.toJSON());
            frame = frame.toJSON();
-          if (endpointId === 1) {
-            this.buttonCommandParser(endpointId, frame);
-          } else {
-            debounce = debounce+1;
-            if (debounce===1){
-              this.buttonCommandParser(endpointId, frame);
-            } else {
-              debounce=0;
-            }
-          }
+           this.buttonCommandParser(endpointId, frame);
         }
       };
 


### PR DESCRIPTION
Here with my Homey early 2023 i don't need the debounce for the switch to work correcly.
If there is a debounce i need to slow press muliple times for the right response.