### PR TITLE
Add missing Door/Windows Sensor to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Supported devices:
     _TZ3000_4ugnzsli / TS0203
     TUYATEC-7qunn4gq / RH3001
     _TZ3000_zgrffiwg / TS0203
+    _TZ3000_decxrtwa / TS0203
     Immax / DoorWindow-Sensor-ZB3.0
     Visonic / MCT-340 E
 

--- a/drivers/doorwindowsensor/driver.compose.json
+++ b/drivers/doorwindowsensor/driver.compose.json
@@ -46,6 +46,7 @@
       "_TZ3000_rgchmad8",
       "_TZ3000_au1rjicn",
       "_TZ3000_4ugnzsli",
+      "_TZ3000_decxrtwa",
       "TUYATEC-7qunn4gq"
     ],
     "productId": [


### PR DESCRIPTION
The device is already configured and working. It was only missing in the list of devices. 