### PR TITLE
Fix UNSUP_GENERAL_COMMAND on Init

### DIFF
--- a/drivers/lcdtemphumidsensor/device.js
+++ b/drivers/lcdtemphumidsensor/device.js
@@ -10,19 +10,6 @@ class lcdtemphumidsensor extends ZigBeeDevice {
 
 		this.printNode();
 
-		if (this.isFirstInit()){
-			await this.configureAttributeReporting([
-				{
-					endpointId: 1,
-					cluster: CLUSTER.POWER_CONFIGURATION,
-					attributeName: 'batteryPercentageRemaining',
-					minInterval: 65535,
-					maxInterval: 0,
-					minChange: 0,
-				}
-			]);
-		}
-
 		// measure_temperature
 		zclNode.endpoints[1].clusters[CLUSTER.TEMPERATURE_MEASUREMENT.NAME]
 		.on('attr.measuredValue', this.onTemperatureMeasuredAttributeReport.bind(this));


### PR DESCRIPTION
This fixes the error message on Init: UNSUP_GENERAL_COMMAND on the TS0201 devices.
Temperature, humidity and batterystatus updates as expected when initialized.

This fixes:
@https://github.com/JohanBendz/com.tuya.zigbee/issues/240
@https://github.com/JohanBendz/com.tuya.zigbee/issues/218
@https://github.com/JohanBendz/com.tuya.zigbee/issues/143