### PR TITLE
Add support for Radar "_TZE204_qasjif9e"

### DIFF
--- a/drivers/radar_sensor/driver.compose.json
+++ b/drivers/radar_sensor/driver.compose.json
@@ -28,7 +28,8 @@
         "_TZE201_ztc6ggyl",
         "_TZE202_ztc6ggyl",
         "_TZE203_ztc6ggyl",
-        "_TZE204_ztc6ggyl"
+        "_TZE204_ztc6ggyl",
+        "_TZE204_qasjif9e"
       ],
       "productId": [
         "TS0601"


### PR DESCRIPTION
Hello,

New into Homey, but I have tested the change in my Homey with the Zigbee device (_TZE204_qasjif9e) and it works great. The following issues can be closed with this change:

https://github.com/JohanBendz/com.tuya.zigbee/issues/550 https://github.com/JohanBendz/com.tuya.zigbee/issues/480

I don't know if I also need to change app.json