### PR TITLE
Support 2 Gang Switch _TZ3000_qaa59zqd

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ Supported devices:
     _TZ3000_18ejxno0 / TS0012
     _TZ3000_llfaquvp / TS0012
     _TZ3000_lmlsduws / TS0002
+-   _TZ3000_qaa59zqd / TS0002
 
 - 2 Gang Switch Module with metering
     _TZ3000_zmy4lslw / TS0002

--- a/app.json
+++ b/app.json
@@ -6532,7 +6532,8 @@
           "_TZ3000_7ed9cqgi",
           "_TZ3000_18ejxno0",
           "_TZ3000_llfaquvp",
-          "_TZ3000_lmlsduws"
+          "_TZ3000_lmlsduws",
+          "_TZ3000_qaa59zqd"
         ],
         "productId": [
           "TS0003",

--- a/drivers/switch_2_gang/driver.compose.json
+++ b/drivers/switch_2_gang/driver.compose.json
@@ -31,7 +31,8 @@
         "_TZ3000_7ed9cqgi",
         "_TZ3000_18ejxno0",
         "_TZ3000_llfaquvp",
-        "_TZ3000_lmlsduws"
+        "_TZ3000_lmlsduws",
+        "_TZ3000_qaa59zqd"
       ],
       "productId": [
         "TS0003",


### PR DESCRIPTION
This adds the Moes/Tuya _Mini 2 Gang Switch Module_.

I've tested it locally, and it works well.

This resolves:
- https://github.com/JohanBendz/com.tuya.zigbee/issues/615
- https://github.com/JohanBendz/com.tuya.zigbee/issues/633
- https://github.com/JohanBendz/com.tuya.zigbee/issues/651