### PR TITLE
Support Tuya/Moes 006 Series Thermostat

### DIFF
--- a/drivers/wall_thermostat/driver.compose.json
+++ b/drivers/wall_thermostat/driver.compose.json
@@ -13,7 +13,7 @@
     "small": "{{driverAssetsPath}}/images/small.jpg"
   },
   "zigbee": {
-    "manufacturerName": "_TZE200_aoclfnxz",
+    "manufacturerName": ["_TZE200_aoclfnxz", "_TZE204_aoclfnxz"],
     "productId": [
       "TS0601"
     ],


### PR DESCRIPTION
Adds support for the [006 Series Thermostat](https://moeshouse.com/products/zigbee-programmable-thermostat-006).

Tested locally.