### PR TITLE
Bugfix: Fix TZ3000_abrsvsou dimmer

### DIFF
--- a/drivers/smart_knob_switch/device.js
+++ b/drivers/smart_knob_switch/device.js
@@ -44,12 +44,11 @@ class smart_knob_switch extends ZigBeeDevice {
       default: btn = 'press'; break; // Button
     };
 
-
     this.log('Processed action: ', btn === false ? 'unknown' : btn);
 
     if (duration !== false) {
-      this.setCapabilityValue('dim', (left ? -1 : 1) * duration).catch(this.error);
-      this.log('Dimming to: ', (left ? -1 : 1) * duration);
+      this.setCapabilityValue('dim', duration/500).catch(this.error);
+      this.log('Dimming to: ', duration/500);
     }
 
     return this._buttonPressedTriggerDevice.trigger(this, {}, { button: `${btn}` })
@@ -64,7 +63,3 @@ class smart_knob_switch extends ZigBeeDevice {
 }
 
 module.exports = smart_knob_switch;
-
-
-
-


### PR DESCRIPTION
The dimmer value has two bugs:
1) Homey flows works much better with a 0-1 base, and according to the docs it should not be minus. Thus you can detect plus/minus depending on the direction turned.
2) The dim reported from the device is 250 per half-turn (as in 500 per one rotation). So the value should be divided by 500.
NOTE: The device is speed-sensitive. A full rotation is max 500 when turning it very fast and minimum 25 if going slow... 100 is the "normal speed"