### PR TITLE
fixes #770, MHCOZY 2-channel relay switch _TZ3000_ruldv5dt / TS0002

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,7 @@ Supported devices:
 
 - 2 Channel Relay Board
     _TZ3000_nuenzetq / TS0002
+    _TZ3000_ruldv5dt / TS0002
 
 - 4 Channel Relay Board
     _TZ3000_hdlpifbk / TS0004

--- a/app.json
+++ b/app.json
@@ -5570,7 +5570,8 @@
       },
       "zigbee": {
         "manufacturerName": [
-          "_TZ3000_nuenzetq"
+          "_TZ3000_nuenzetq",
+          "_TZ3000_ruldv5dt"
         ],
         "productId": [
           "TS0002"

--- a/drivers/relay_board_2_channel/driver.compose.json
+++ b/drivers/relay_board_2_channel/driver.compose.json
@@ -21,7 +21,8 @@
     },
     "zigbee": {
       "manufacturerName": [
-        "_TZ3000_nuenzetq"
+        "_TZ3000_nuenzetq",
+        "_TZ3000_ruldv5dt"
       ],
       "productId": [
         "TS0002"


### PR DESCRIPTION
Fixes https://github.com/JohanBendz/com.tuya.zigbee/issues/770. 
Will now properly support _TZ3000_ruldv5dt  as two devices that can individually be switched in all three modes instead of just finding one generic zigbee device that mixes up the two relais in just one device.