### PR TITLE
fixes #1059, RGB LED Strip Controller, _TZ3210_eejm8dcr / TS0505B

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,6 +591,7 @@ Supported devices:
     _TZ3000_i8l0nqdu / TS0503B
     _TZ3000_ukuvyhaa / TS0504B
     _TZ3210_k1pe6ibm / TS0505B
+    _TZ3210_eejm8dcr / TS0505B
 
 - RGB Spot GU10
     _TZ3000_kdpxju99 / TS0505A (LIVARNO LUX / Lidl)

--- a/app.json
+++ b/app.json
@@ -6225,7 +6225,8 @@
           "_TZ3000_qqjaziws",
           "_TZ3000_i8l0nqdu",
           "_TZ3000_ukuvyhaa",
-          "_TZ3210_k1pe6ibm"
+          "_TZ3210_k1pe6ibm",
+          "_TZ3210_eejm8dcr"
         ],
         "productId": [
           "TS0503A",

--- a/drivers/rgb_led_strip_controller/driver.compose.json
+++ b/drivers/rgb_led_strip_controller/driver.compose.json
@@ -17,7 +17,8 @@
         "_TZ3000_qqjaziws",
         "_TZ3000_i8l0nqdu",
         "_TZ3000_ukuvyhaa",
-        "_TZ3210_k1pe6ibm"
+        "_TZ3210_k1pe6ibm",
+        "_TZ3210_eejm8dcr"
       ],
       "productId": [
         "TS0503A",


### PR DESCRIPTION
Fixes https://github.com/JohanBendz/com.tuya.zigbee/issues/1059 by adding new manufacturer id. This way the light strip with Zigbee controller can be registered in this app instead of being a generic zigbee light.