### PR TITLE
Added _TZ3000_an5rjiwd to smart_button_switch

### DIFF
--- a/drivers/smart_button_switch/driver.compose.json
+++ b/drivers/smart_button_switch/driver.compose.json
@@ -21,7 +21,8 @@
       "manufacturerName": [
         "_TZ3000_fa9mlvja",
         "_TZ3000_yj6k7vfo",
-        "_TZ3000_qgwcxxws"
+        "_TZ3000_qgwcxxws",
+        "_TZ3000_an5rjiwd"
       ],
       "productId": [
         "TS0041"


### PR DESCRIPTION
Added new Produkt-ID of the Tuya Zigbee Smart Button ([Link to AliExpress](https://de.aliexpress.com/item/1005007408323753.html?spm=a2g0o.productlist.main.1.55ceHB9SHB9SgJ&algo_pvid=37c7818c-5839-4337-9885-c46cea0b9d3e&algo_exp_id=37c7818c-5839-4337-9885-c46cea0b9d3e-0&pdp_npi=4%40dis%21EUR%214.60%210.99%21%21%2133.95%217.29%21%402103856417371940747871480ef80b%2112000040628830593%21sea%21DE%210%21ABX&curPageLogUid=RCEKQTMFfWpL&utparam-url=scene%3Asearch%7Cquery_from%3A)).