### PR TITLE
Add support for Tuya PIR sensor TS0202 / "_TZ3000_c8ozah8n"

### DIFF
--- a/drivers/pir_sensor_2/driver.compose.json
+++ b/drivers/pir_sensor_2/driver.compose.json
@@ -33,7 +33,8 @@
       "_TZ3040_bb6xaihh",
       "_TZ3000_nss8amz9",
       "_TZ3000_bsvqrxru",
-      "_TYZB01_dr6sduka"
+      "_TYZB01_dr6sduka",
+      "_TZ3000_c8ozah8n"
     ],
     "productId": [
       "TS0202"


### PR DESCRIPTION
Add the manufacturerName "_TZ3000_c8ozah8n" for the "pir_sensor_2" driver.