### PR TITLE
Add "_TZE204_bjzrowv2" - Update driver.compose.json

### DIFF
--- a/drivers/curtain_motor/driver.compose.json
+++ b/drivers/curtain_motor/driver.compose.json
@@ -52,7 +52,8 @@
         "_TZE200_yia0p3tr",
         "_TZE200_nw1r9hp6",
         "_TZE200_cf1sl3tj",
-        "_TZE200_9p5xmj5r"
+        "_TZE200_9p5xmj5r",
+        "_TZE204_bjzrowv2"
       ],
       "productId": [
         "TS0601"


### PR DESCRIPTION
Added "_TZE204_bjzrowv2" to the "manufacturerName".
It was requested by Issue #1186 - Device Request - ZigBee Intelligent curtain motor - Autorail "_TZE204_bjzrowv2" / "TS0601".