### PR TITLE
Add Quoya M515EGBZTN support and fix curtain_motor position inversion

### DIFF
--- a/app.json
+++ b/app.json
@@ -1317,6 +1317,48 @@
         ]
       },
       {
+        "id": "set_upper_limit",
+        "title": {
+          "en": "Set upper limit at current position",
+          "nl": "Bovengrens instellen op huidige positie"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=curtain_motor"
+          }
+        ]
+      },
+      {
+        "id": "set_lower_limit",
+        "title": {
+          "en": "Set lower limit at current position",
+          "nl": "Ondergrens instellen op huidige positie"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=curtain_motor"
+          }
+        ]
+      },
+      {
+        "id": "remove_limits",
+        "title": {
+          "en": "Remove upper and lower limits",
+          "nl": "Boven- en ondergrens verwijderen"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=curtain_motor"
+          }
+        ]
+      },
+      {
         "id": "fingerbot_push",
         "title": {
           "en": "Push"
@@ -2529,7 +2571,9 @@
           "_TZE200_nw1r9hp6",
           "_TZE200_cf1sl3tj",
           "_TZE200_9p5xmj5r",
-          "_TZE204_xu4a5rhj"
+          "_TZE204_xu4a5rhj",
+          "_TZE200_gubdgai2",
+          "_TZE200_vdiuwbkq"
         ],
         "productId": [
           "TS0601"
@@ -2583,6 +2627,33 @@
               }
             }
           ]
+        },
+        {
+          "id": "set_upper_limit",
+          "type": "checkbox",
+          "label": {
+            "en": "Set upper limit at current position",
+            "nl": "Bovengrens instellen op huidige positie"
+          },
+          "value": false
+        },
+        {
+          "id": "set_lower_limit",
+          "type": "checkbox",
+          "label": {
+            "en": "Set lower limit at current position",
+            "nl": "Ondergrens instellen op huidige positie"
+          },
+          "value": false
+        },
+        {
+          "id": "remove_limits",
+          "type": "checkbox",
+          "label": {
+            "en": "Remove upper and lower limits",
+            "nl": "Boven- en ondergrens verwijderen"
+          },
+          "value": false
         },
         {
           "id": "max_open_percentage",

--- a/drivers/curtain_motor/device.js
+++ b/drivers/curtain_motor/device.js
@@ -10,6 +10,15 @@ const dataPoints = {
   position: 2,
   arrived: 3,
   motorReverse: 4,
+  border: 16,
+}
+
+const borderValues = {
+  up: 0,
+  down: 1,
+  up_delete: 2,
+  down_delete: 3,
+  remove_top_bottom: 4,
 }
 
 const dataTypes = {
@@ -68,6 +77,13 @@ class CurtainMotor extends TuyaSpecificClusterDevice {
         this.error('Error when reading device attributes ', err);
     });
 
+    this.homey.flow.getActionCard('set_upper_limit')
+      .registerRunListener((args) => args.device.writeEnum(dataPoints.border, borderValues.up));
+    this.homey.flow.getActionCard('set_lower_limit')
+      .registerRunListener((args) => args.device.writeEnum(dataPoints.border, borderValues.down));
+    this.homey.flow.getActionCard('remove_limits')
+      .registerRunListener((args) => args.device.writeEnum(dataPoints.border, borderValues.remove_top_bottom));
+
   }
 
   async setPosition(pos) {
@@ -81,7 +97,7 @@ class CurtainMotor extends TuyaSpecificClusterDevice {
     if (pos === undefined) {
       pos = this.getCapabilityValue('pos');
     } else {
-      pos = reverse ? 1 - pos : pos;
+      pos = reverse ? pos : 1 - pos;
     }
 
     return this.writeData32(dataPoints.position, pos * 100);
@@ -109,6 +125,18 @@ class CurtainMotor extends TuyaSpecificClusterDevice {
   async onSettings({oldSettings, newSettings, changedKeys}) {
     if (changedKeys.includes('reverse')) {
       this.setCapabilityValue('windowcoverings_set', 1 - this.getCapabilityValue('windowcoverings_set')).catch(this.error);
+    }
+    if (changedKeys.includes('set_upper_limit') && newSettings.set_upper_limit) {
+      await this.writeEnum(dataPoints.border, borderValues.up);
+      this.setSettings({ set_upper_limit: false }).catch(this.error);
+    }
+    if (changedKeys.includes('set_lower_limit') && newSettings.set_lower_limit) {
+      await this.writeEnum(dataPoints.border, borderValues.down);
+      this.setSettings({ set_lower_limit: false }).catch(this.error);
+    }
+    if (changedKeys.includes('remove_limits') && newSettings.remove_limits) {
+      await this.writeEnum(dataPoints.border, borderValues.remove_top_bottom);
+      this.setSettings({ remove_limits: false }).catch(this.error);
     }
   }
 

--- a/drivers/curtain_motor/driver.compose.json
+++ b/drivers/curtain_motor/driver.compose.json
@@ -53,7 +53,9 @@
         "_TZE200_nw1r9hp6",
         "_TZE200_cf1sl3tj",
         "_TZE200_9p5xmj5r",
-        "_TZE204_xu4a5rhj"
+        "_TZE204_xu4a5rhj",
+        "_TZE200_gubdgai2",
+        "_TZE200_vdiuwbkq"
       ],
       "productId": [
         "TS0601"

--- a/drivers/curtain_motor/driver.flow.compose.json
+++ b/drivers/curtain_motor/driver.flow.compose.json
@@ -1,0 +1,25 @@
+{
+    "actions": [
+      {
+        "id": "set_upper_limit",
+        "title": {
+          "en": "Set upper limit at current position",
+          "nl": "Bovengrens instellen op huidige positie"
+        }
+      },
+      {
+        "id": "set_lower_limit",
+        "title": {
+          "en": "Set lower limit at current position",
+          "nl": "Ondergrens instellen op huidige positie"
+        }
+      },
+      {
+        "id": "remove_limits",
+        "title": {
+          "en": "Remove upper and lower limits",
+          "nl": "Boven- en ondergrens verwijderen"
+        }
+      }
+    ]
+  }

--- a/drivers/curtain_motor/driver.settings.compose.json
+++ b/drivers/curtain_motor/driver.settings.compose.json
@@ -25,6 +25,33 @@
     ]
   },
   {
+    "id": "set_upper_limit",
+    "type": "checkbox",
+    "label": {
+      "en": "Set upper limit at current position",
+      "nl": "Bovengrens instellen op huidige positie"
+    },
+    "value": false
+  },
+  {
+    "id": "set_lower_limit",
+    "type": "checkbox",
+    "label": {
+      "en": "Set lower limit at current position",
+      "nl": "Ondergrens instellen op huidige positie"
+    },
+    "value": false
+  },
+  {
+    "id": "remove_limits",
+    "type": "checkbox",
+    "label": {
+      "en": "Remove upper and lower limits",
+      "nl": "Boven- en ondergrens verwijderen"
+    },
+    "value": false
+  },
+  {
     "id": "max_open_percentage",
     "type": "number",
     "label": {


### PR DESCRIPTION
## Summary

Adds support for the Quoya M515EGBZTN Zigbee roller blind / plissé motor and fixes two existing issues in the `curtain_motor` driver.

Tested on Homey Pro (Early 2023), firmware 13.2.1-rc.4, with two M515EGBZTN devices running simultaneously.

Closes #1405

---

### Changes

**New fingerprints**
- `_TZE200_gubdgai2` — Quoya M515EGBZTN
- `_TZE200_vdiuwbkq` — Quoya M515EGBZTN (alternate)

**Bug fix: position inversion in `setPosition`**

The device uses `0 = fully open, 100 = fully closed`, opposite to Homey's `windowcoverings_set` (0 = closed, 1 = open). `updatePosition` already handles this correctly with `100 - value`, but `setPosition` was not inverting — so setting the slider to 0% sent `0` to the device, which opened the blinds instead of closing them.

```js
// before
pos = reverse ? 1 - pos : pos;

// after
pos = reverse ? pos : 1 - pos;
```

This bug likely affects other TS0601 curtain motors with the same `0=open` convention.

**Upper/lower limit support (DP 16)**

Exposes the device's physical end-stop programming via DP 16 (`border`):

| Enum | Action |
|---|---|
| 0 | Set upper limit at current position |
| 1 | Set lower limit at current position |
| 4 | Remove both limits |

- Three flow action cards added via `driver.flow.compose.json`
- Three checkbox settings added to the device settings screen as a direct alternative to flow cards (Homey has no `button` type for device settings; the checkbox resets itself after firing)
- Flow card listeners use `args.device` pattern to correctly support multiple curtain motor devices

## Test plan

- [x] Pair a `_TZE200_gubdgai2` or `_TZE200_vdiuwbkq` device — should be recognised as `curtain_motor`
- [x] Slider at 0% closes the blinds, 100% opens them
- [ ] "Reverse direction" setting still works correctly
- [x] Set upper limit: move blinds to desired top position → tick checkbox in device settings → motor stores position
- [x] Set lower limit: same for bottom position
- [ ] Remove limits: clears both end stops
- [ ] Flow action cards appear in Homey flows for the device

🤖 Generated with [Claude Code](https://claude.com/claude-code)