### PR TITLE
Add Zbeacon manufacturer to smartplug driver (TS011F)

### DIFF
--- a/app.json
+++ b/app.json
@@ -8256,7 +8256,8 @@
           "_TZ3000_fukaa7nc",
           "_TZ3000_88iqnhvd",
           "_TZ3000_3ias4w4o",
-          "_TZ3000_wzmuk9ai"
+          "_TZ3000_wzmuk9ai",
+          "Zbeacon"
         ],
         "productId": [
           "TS0121",

--- a/drivers/smartplug/driver.compose.json
+++ b/drivers/smartplug/driver.compose.json
@@ -72,7 +72,8 @@
       "_TZ3000_fukaa7nc",
       "_TZ3000_88iqnhvd",
       "_TZ3000_3ias4w4o",
-      "_TZ3000_wzmuk9ai"
+      "_TZ3000_wzmuk9ai",
+      "Zbeacon"
     ],
     "productId": [
       "TS0121",


### PR DESCRIPTION
## Summary

- Adds `Zbeacon` to the `manufacturerName` fingerprint list in the `smartplug` driver

## Problem

TS011F smart plugs sold under the **Zbeacon** brand are not matched by the `smartplug` driver because `Zbeacon` is missing from the `manufacturerName` list. Homey falls back to the built-in virtual Zigbee driver, which reads raw cluster values without correct scaling — resulting in impossible readings (e.g. **48 A** instead of ~0.05 A for a USB charger in standby).

## Device info

| Field | Value |
|---|---|
| `zb_product_id` | TS011F |
| `zb_manufacturer_name` | Zbeacon |
| `zb_sw_build_id` | 1.0.5 |
| `zb_device_type` | router |

## Fix

One line added to `drivers/smartplug/driver.compose.json` + rebuilt `app.json`.

After re-pairing with the `smartplug` driver, energy measurement works correctly:
- `measure_current`: 0.05 A ✓ (USB charger idle)
- `measure_voltage`: 224 V ✓
- `measure_power`: 0 W ✓ (below ~1 W detection threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)