### PR TITLE
Add HOBEIAN ZG-305Z (2-channel USB switch) to switch_2_gang

### DIFF
--- a/drivers/switch_2_gang/driver.compose.json
+++ b/drivers/switch_2_gang/driver.compose.json
@@ -34,6 +34,7 @@
         "_TZ3000_qaa59zqd",
         "_TZ3000_qcgw8qfa",
         "_TZ3000_jcfje0kb",
+        "HOBEIAN",
         "_TZ3000_ruxexjfz"
       ],
       "productId": [
@@ -41,6 +42,7 @@
         "TS0012",
         "TS011F",
         "TS0002",
+        "ZG-305Z",
         "TS0013"
       ],
       "endpoints": {


### PR DESCRIPTION
Adds the fingerprint for the HOBEIAN ZG-305Z, a 2-channel Zigbee on/off switch (sold as an MHCOZY dual USB-C switch). It currently falls through to Homey's generic Zigbee driver.

- manufacturerName: HOBEIAN
- productId: ZG-305Z
- Standard on/off clusters on endpoints 1 and 2 — matches the existing switch_2_gang endpoint definition, creates two tiles (one per channel).
- Verified working on Homey Pro (both channels switch independently).

Referenced in zigbee2mqtt as a 2-gang switch (state_l1 / state_l2).