### PR TITLE
Add Wing manufacturer name to TS0203 door/window sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Supported devices:
     _TZ3000_cqlnswn0 / TY0203 (TESLA)
     _TZ3000_qrldbmfn / TS0203
     _TZ3000_gntwytxo / TS0203
+    Wing / TS0203 (Wing)
     _TZ3000_n2egfsli / SNZB-04
 
 - Water Detector

--- a/app.json
+++ b/app.json
@@ -3233,7 +3233,8 @@
           "_TZ3000_au2o5e6q",
           "_TZ3000_v7chgqso",
           "_TZ3000_qrldbmfn",
-          "_TZ3000_gntwytxo"
+          "_TZ3000_gntwytxo",
+          "Wing"
         ],
         "productId": [
           "RH3001",

--- a/drivers/doorwindowsensor/driver.compose.json
+++ b/drivers/doorwindowsensor/driver.compose.json
@@ -60,7 +60,8 @@
       "_TZ3000_au2o5e6q",
       "_TZ3000_v7chgqso",
       "_TZ3000_qrldbmfn",
-      "_TZ3000_gntwytxo"
+      "_TZ3000_gntwytxo",
+      "Wing"
     ],
     "productId": [
       "RH3001",


### PR DESCRIPTION
## Current situation

A Wing branded door/window contact sensor is not recognised by the app. During pairing Homey reports:

```
zb_product_id        TS0203
zb_manufacturer_name Wing
```

`TS0203` is already supported by several drivers, but every entry in `manufacturerName` uses a `_TZ3000_*` / `TUYATEC-*` identifier. Wing ships this sensor with the plain brand name `Wing` as the manufacturer name, so no driver matches and the device cannot be added.

`Wing` is a manufacturer name that already shows up for other devices in this app's issue tracker (#1422, #1429 for the Wing ZTH11-3.0 / ZTH13-3.0 sensors), so the plain brand name is what these devices actually report.

## Change

Adds `Wing` to the `manufacturerName` list of the `doorwindowsensor` driver — the generic TS0203 driver (`alarm_contact` + `alarm_battery`, IAS Zone status notifications). No code changes are needed; the device behaves as a standard IAS Zone contact sensor.

- `drivers/doorwindowsensor/driver.compose.json` — added `Wing`
- `app.json` — regenerated entry to match
- `README.md` — added to the supported Door/Windows Sensor list

This follows the precedent of other non-`_TZ`-prefixed entries already in the door/window drivers (`Immax`, `Visonic`, `zbeacon`).

## Notes for the reviewer

Marked as draft: I have the hardware, but I would like confirmation that `doorwindowsensor` is the driver you prefer for this one before it is merged. `doorwindowsensor_2` (adds `alarm_tamper`) and `doorwindowsensor_3` are alternatives; the plain `doorwindowsensor` driver was chosen because it is the general TS0203 catch-all and the Wing sensor exposes no tamper contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)