### PR TITLE
Add _TZ3210_ddigca5n (TS011F metering plug) to smartplug

### DIFF
--- a/drivers/smartplug/driver.compose.json
+++ b/drivers/smartplug/driver.compose.json
@@ -24,6 +24,7 @@
   },
   "zigbee": {
     "manufacturerName": [
+      "_TZ3210_ddigca5n",
       "_TZ3000_3ooaz3ng",
       "_TYZB01_iuepbmpv",
       "_TZ3000_g5xawfcq",


### PR DESCRIPTION
Adds the _TZ3210_ddigca5n manufacturer variant of the TS011F metering plug to the smartplug driver. It currently falls back to Homey's generic Zigbee driver.

The smartplug driver already polls the electrical-measurement cluster via getOpts.pollInterval (these Tuya firmwares don't push power reports on change, so polling is required — same approach zigbee2mqtt uses). No driver code change needed; this is a fingerprint addition only.